### PR TITLE
feature(App): create auth module

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig([
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/cookie-parser": "^1.4.9",
+        "@types/jsonwebtoken": "^9.0.9",
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.0",
         "reflect-metadata": "^0.2.2",
         "tsconfig-paths": "^4.2.0",
@@ -518,7 +522,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -529,10 +532,18 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -555,7 +566,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
       "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -567,7 +577,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
       "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -580,7 +589,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -590,18 +598,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
+      "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.15.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
       "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -685,21 +707,18 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -710,7 +729,6 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1246,6 +1264,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1435,6 +1459,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -1581,6 +1624,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2590,6 +2642,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2630,11 +2725,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -3479,7 +3616,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4224,7 +4360,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,14 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@types/cookie-parser": "^1.4.9",
+    "@types/jsonwebtoken": "^9.0.9",
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "tsconfig-paths": "^4.2.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express';
+import { AbstractController } from 'common/abstract';
+import { JwtService } from 'common/services';
+
+class AuthControllerClass extends AbstractController {
+  constructor(private readonly jwtService = JwtService) {
+    super();
+  }
+
+  refresh(req: Request, res: Response) {
+    const { access_token, refresh_token } = this.jwtService.signTokensPair(
+      req.user,
+    );
+
+    this.setRefreshTokenCookie(res, refresh_token);
+    res.json({ access_token });
+  }
+}
+
+export const AuthController = new AuthControllerClass();

--- a/src/auth/auth.entity.ts
+++ b/src/auth/auth.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { UserEntity } from 'user/user.entity';
+import { AuthProvider } from './auth.types';
+
+@Entity('auth')
+export class AuthEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'enum', enum: AuthProvider, default: AuthProvider.LOCAL })
+  provider: AuthProvider;
+
+  @Column()
+  email: string;
+
+  @Column({ nullable: true })
+  password?: string;
+
+  @ManyToOne(() => UserEntity, (user) => user.id, { onDelete: 'CASCADE' })
+  user: UserEntity;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -1,0 +1,33 @@
+import { AppDataSource } from 'database';
+import { AuthEntity } from './auth.entity';
+import { AuthProvider } from './auth.types';
+import { FindOptionsWhere } from 'typeorm';
+
+export class AuthRepositoryClass {
+  constructor(
+    private readonly authRepository = AppDataSource.getRepository(AuthEntity),
+  ) {}
+
+  findByEmailAndProvider(
+    email: string,
+    provider: AuthProvider,
+  ): Promise<AuthEntity | null> {
+    return this.authRepository.findOne({
+      where: { email, provider } as FindOptionsWhere<AuthEntity>,
+      relations: ['user'],
+    });
+  }
+
+  create(data: Partial<AuthEntity>): Promise<AuthEntity> {
+    const entity = this.authRepository.create(data);
+    return this.authRepository.save(entity);
+  }
+
+  findAllByUser(userId: number): Promise<AuthEntity[]> {
+    return this.authRepository.find({
+      where: { user: { id: userId } },
+    });
+  }
+}
+
+export const AuthRepository = new AuthRepositoryClass();

--- a/src/auth/auth.routes.ts
+++ b/src/auth/auth.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { AuthController } from './auth.controller';
+import { refreshTokenMiddleware } from 'auth/middlewares';
+import { authLocalRouter } from './providers/local/auth.local.routes';
+
+export const authRouter = Router();
+
+// MAIN ROUTES
+authRouter.get('/refresh', refreshTokenMiddleware, AuthController.refresh);
+
+// LOCAL PROVIDER ROUTES
+authRouter.use('/local', authLocalRouter);

--- a/src/auth/auth.types.ts
+++ b/src/auth/auth.types.ts
@@ -1,0 +1,4 @@
+// ! enums
+export enum AuthProvider {
+  LOCAL = 'local',
+}

--- a/src/auth/middlewares/access-token.middleware.ts
+++ b/src/auth/middlewares/access-token.middleware.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Request, Response } from 'express';
+import { JwtService } from 'common/services';
+import { UnauthorizedException } from 'common/exceptions';
+
+export function accessTokenMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new UnauthorizedException(
+      'Authorization header is missing or invalid',
+    );
+  }
+
+  const [, access_token] = authHeader.split(' ');
+
+  if (!access_token) {
+    throw new UnauthorizedException('Access token is missing');
+  }
+
+  try {
+    req.user = JwtService.verify(access_token);
+    next();
+  } catch (_err) {
+    throw new UnauthorizedException();
+  }
+}

--- a/src/auth/middlewares/index.ts
+++ b/src/auth/middlewares/index.ts
@@ -1,0 +1,2 @@
+export { accessTokenMiddleware } from './access-token.middleware';
+export { refreshTokenMiddleware } from './refresh-token.middleware';

--- a/src/auth/middlewares/refresh-token.middleware.ts
+++ b/src/auth/middlewares/refresh-token.middleware.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+import { UnauthorizedException } from 'common/exceptions';
+import { JwtService } from 'common/services';
+
+export function refreshTokenMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) {
+  const refreshToken = req.cookies?.refresh_token;
+
+  if (!refreshToken) {
+    throw new UnauthorizedException('Refresh token is missing');
+  }
+
+  try {
+    req.user = JwtService.verify(refreshToken);
+    next();
+  } catch {
+    throw new UnauthorizedException();
+  }
+}

--- a/src/auth/providers/local/auth.local.controller.ts
+++ b/src/auth/providers/local/auth.local.controller.ts
@@ -1,0 +1,31 @@
+import { Response } from 'express';
+import { TypedRequest } from 'common/types';
+import { AbstractController } from 'common/abstract';
+import { LoginLocalDto, RegisterLocalDto } from './auth.local.types';
+import { AuthLocalService } from './auth.local.service';
+
+class AuthLocalControllerClass extends AbstractController {
+  constructor(private readonly authService = AuthLocalService) {
+    super();
+  }
+
+  async login(req: TypedRequest<{ body: LoginLocalDto }>, res: Response) {
+    const { access_token, refresh_token } = await this.authService.login(
+      req.body,
+    );
+
+    this.setRefreshTokenCookie(res, refresh_token);
+    res.json({ access_token });
+  }
+
+  async register(req: TypedRequest<{ body: RegisterLocalDto }>, res: Response) {
+    const { access_token, refresh_token } = await this.authService.register(
+      req.body,
+    );
+
+    this.setRefreshTokenCookie(res, refresh_token);
+    res.json({ access_token });
+  }
+}
+
+export const AuthLocalController = new AuthLocalControllerClass();

--- a/src/auth/providers/local/auth.local.routes.ts
+++ b/src/auth/providers/local/auth.local.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { validateMiddleware } from 'common/middleware';
+import { LoginLocalSchema, RegisterLocalSchema } from './auth.local.schemas';
+import { AuthLocalController } from './auth.local.controller';
+
+export const authLocalRouter = Router();
+
+authLocalRouter.post(
+  '/login',
+  validateMiddleware({ body: LoginLocalSchema }),
+  AuthLocalController.login,
+);
+
+authLocalRouter.post(
+  '/register',
+  validateMiddleware({ body: RegisterLocalSchema }),
+  AuthLocalController.register,
+);

--- a/src/auth/providers/local/auth.local.schemas.ts
+++ b/src/auth/providers/local/auth.local.schemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { CreateUserSchema } from 'user/user.schemas';
+import { EmailFieldSchema } from 'common/schemas';
+
+const PasswordFieldSchema = z
+  .string({ message: 'password is required' })
+  .min(6, { message: 'min password length is 6' });
+
+export const RegisterLocalSchema = CreateUserSchema.extend({
+  password: PasswordFieldSchema,
+}).strict({
+  message: 'Register payload must not contain unknown fields',
+});
+
+export const LoginLocalSchema = z
+  .object({
+    email: EmailFieldSchema,
+    password: PasswordFieldSchema,
+  })
+  .strict({
+    message: 'Login payload must not contain unknown fields',
+  });

--- a/src/auth/providers/local/auth.local.service.ts
+++ b/src/auth/providers/local/auth.local.service.ts
@@ -1,0 +1,81 @@
+// auth
+import { AuthProvider } from 'auth/auth.types';
+import { AuthRepository } from 'auth/auth.repository';
+import { LoginLocalDto, RegisterLocalDto } from './auth.local.types';
+// common
+import { ActiveUser } from 'common/types';
+import { BadRequestException, UnauthorizedException } from 'common/exceptions';
+import { CryptoService, JwtService } from 'common/services';
+// user
+import { UserRepository } from 'user/user.repository';
+
+class AuthLocalServiceClass {
+  constructor(
+    private readonly jwtService = JwtService,
+    private readonly cryptoService = CryptoService,
+    private readonly authRepository = AuthRepository,
+    private readonly userRepository = UserRepository,
+  ) {}
+
+  async login(data: LoginLocalDto): Promise<{
+    access_token: string;
+    refresh_token: string;
+  }> {
+    const auth = await this.authRepository.findByEmailAndProvider(
+      data.email,
+      AuthProvider.LOCAL,
+    );
+
+    if (!auth || !auth.password) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const isMatch = await this.cryptoService.compare(
+      data.password,
+      auth.password,
+    );
+    if (!isMatch) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const activeUser: ActiveUser = { id: auth.user.id, email: auth.user.email };
+
+    return this.jwtService.signTokensPair(activeUser);
+  }
+
+  async register(data: RegisterLocalDto): Promise<{
+    access_token: string;
+    refresh_token: string;
+  }> {
+    const existing = await this.authRepository.findByEmailAndProvider(
+      data.email,
+      AuthProvider.LOCAL,
+    );
+
+    if (existing) {
+      throw new BadRequestException('User with this email already exists');
+    }
+
+    const hashedPassword = await this.cryptoService.hash(data.password);
+
+    const user = await this.userRepository.create({
+      name: data.name,
+      surname: data.surname,
+      birthday: data.birthday,
+      email: data.email,
+    });
+
+    await this.authRepository.create({
+      provider: AuthProvider.LOCAL,
+      email: data.email,
+      password: hashedPassword,
+      user,
+    });
+
+    const activeUser: ActiveUser = { id: user.id, email: user.email };
+
+    return this.jwtService.signTokensPair(activeUser);
+  }
+}
+
+export const AuthLocalService = new AuthLocalServiceClass();

--- a/src/auth/providers/local/auth.local.types.ts
+++ b/src/auth/providers/local/auth.local.types.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { LoginLocalSchema, RegisterLocalSchema } from './auth.local.schemas';
+
+export type LoginLocalDto = z.infer<typeof LoginLocalSchema>;
+
+export type RegisterLocalDto = z.infer<typeof RegisterLocalSchema>;

--- a/src/common/abstract/abstract.controller.ts
+++ b/src/common/abstract/abstract.controller.ts
@@ -1,7 +1,15 @@
 import { autobind } from 'common/utils';
+import { Response } from 'express';
 
 export abstract class AbstractController {
   protected constructor() {
     autobind(this);
+  }
+
+  setRefreshTokenCookie(res: Response, token: string) {
+    res.cookie('refresh_token', token, {
+      httpOnly: true,
+      sameSite: 'strict',
+    });
   }
 }

--- a/src/common/middleware/validate-middleware/validate.middleware.ts
+++ b/src/common/middleware/validate-middleware/validate.middleware.ts
@@ -1,17 +1,12 @@
 import { NextFunction, Request, Response } from 'express';
 import { BadRequestException } from 'common/exceptions';
 import { MiddlewareConfig, MiddlewareReturnType } from './types';
-import { QueryParamsTaskDto } from '../../../task/task.types';
-
-interface AugmentedRequest extends Request {
-  validatedQuery?: QueryParamsTaskDto;
-}
 
 export const validateMiddleware =
   <Config extends MiddlewareConfig>(
     config: Config,
   ): MiddlewareReturnType<Config> =>
-  (req: AugmentedRequest, _res: Response, next: NextFunction) => {
+  (req: Request, _res: Response, next: NextFunction) => {
     Object.entries(config).forEach(([key, schema]) => {
       const location = key as keyof MiddlewareConfig;
 

--- a/src/common/schemas/email-field.schema.ts
+++ b/src/common/schemas/email-field.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const EmailFieldSchema = z
+  .string({ message: 'email is required' })
+  .email({ message: 'email is invalid' });

--- a/src/common/schemas/index.ts
+++ b/src/common/schemas/index.ts
@@ -1,2 +1,3 @@
 export * from './parse-int.schema';
+export * from './email-field.schema';
 export * from './query-params-dto.schema';

--- a/src/common/services/index.ts
+++ b/src/common/services/index.ts
@@ -1,1 +1,2 @@
 export * from './crypto-service';
+export * from './jwt-service';

--- a/src/common/services/jwt-service/index.ts
+++ b/src/common/services/jwt-service/index.ts
@@ -1,0 +1,1 @@
+export * from './jwt.service';

--- a/src/common/services/jwt-service/jwt.config.ts
+++ b/src/common/services/jwt-service/jwt.config.ts
@@ -1,0 +1,13 @@
+import { JwtEnvSchema } from './jwt.schema';
+
+const parsedEnvConfig = JwtEnvSchema.safeParse({
+  access_ttl: process.env.ACCESS_TOKEN_TTL,
+  refresh_ttl: process.env.REFRESH_TOKEN_TTL,
+  secret: process.env.JWT_SECRET,
+});
+
+if (!parsedEnvConfig.success) {
+  throw new Error('Invalid JWT environment variables');
+}
+
+export const jwtEnvConfig = parsedEnvConfig.data;

--- a/src/common/services/jwt-service/jwt.schema.ts
+++ b/src/common/services/jwt-service/jwt.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const JwtEnvSchema = z.object({
+  access_ttl: z.coerce.number().min(1),
+  refresh_ttl: z.coerce.number().min(1),
+  secret: z.string().nonempty(),
+});
+
+export const ActiveUserSchema = z.object({
+  id: z.coerce.number(),
+  email: z.string().nonempty(),
+});

--- a/src/common/services/jwt-service/jwt.service.ts
+++ b/src/common/services/jwt-service/jwt.service.ts
@@ -1,0 +1,37 @@
+import jwt from 'jsonwebtoken';
+import { jwtEnvConfig } from './jwt.config';
+import { ActiveUser } from 'common/types';
+import { ActiveUserSchema } from 'common/services/jwt-service/jwt.schema';
+
+class JwtServiceClass {
+  signAccessToken(payload: ActiveUser): string {
+    return jwt.sign(payload, jwtEnvConfig.secret, {
+      expiresIn: `${jwtEnvConfig.access_ttl}m`,
+    });
+  }
+
+  signRefreshToken(payload: ActiveUser): string {
+    return jwt.sign(payload, jwtEnvConfig.secret, {
+      expiresIn: `${jwtEnvConfig.refresh_ttl}m`,
+    });
+  }
+
+  signTokensPair(payload: ActiveUser) {
+    const access_token = this.signAccessToken(payload);
+    const refresh_token = this.signRefreshToken(payload);
+
+    return { access_token, refresh_token };
+  }
+
+  verify(token: string): ActiveUser {
+    try {
+      const decoded = jwt.verify(token, jwtEnvConfig.secret);
+
+      return ActiveUserSchema.parse(decoded);
+    } catch (_err) {
+      throw new Error('Invalid or expired token');
+    }
+  }
+}
+
+export const JwtService = new JwtServiceClass();

--- a/src/common/types/common.ts
+++ b/src/common/types/common.ts
@@ -1,0 +1,14 @@
+// ! ENUMS
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export interface MessageResponse {
+  message: string;
+}
+
+export interface ActiveUser {
+  id: number;
+  email: string;
+}

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,0 +1,2 @@
+export * from './utils';
+export * from './common';

--- a/src/common/types/utils.ts
+++ b/src/common/types/utils.ts
@@ -1,20 +1,16 @@
 import { Request } from 'express';
 
-// ! ENUMS
+export type Nullable<T> = T | null;
 
-export enum SortOrder {
-  ASC = 'asc',
-  DESC = 'desc',
-}
+export type Maybe<T> = T | undefined;
 
-// ! TYPES
 export type TypedRequest<
   T extends {
     params?: unknown;
     query?: unknown;
     body?: unknown;
     validatedQuery?: unknown;
-  },
+  } = object,
 > = Request<
   T['params'] extends undefined ? unknown : T['params'],
   unknown,
@@ -25,10 +21,3 @@ export type TypedRequest<
     ? unknown
     : T['validatedQuery'];
 };
-
-export interface MessageResponse {
-  message: string;
-}
-
-export type Nullable<T> = T | null;
-export type Maybe<T> = T | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+// Load custom type extensions
+import 'type-extensions/express-config';
+
 // other imports
 import express from 'express';
 import cors from 'cors';
@@ -10,9 +13,12 @@ import { rootRouter } from 'routes';
 import { connectDatabase } from 'database';
 import { errorHandler } from 'common/middleware';
 import { NotFoundException } from 'common/exceptions';
+import cookieParser from 'cookie-parser';
 
 // App init
 const app = express();
+
+app.use(cookieParser());
 
 app.use(
   cors({

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express';
-import { taskRouter } from 'task';
-import { userRouter } from 'user';
+import { taskRouter } from 'task/task.routes';
+import { userRouter } from 'user/user.routes';
+import { authRouter } from 'auth/auth.routes';
+import { accessTokenMiddleware } from 'auth/middlewares';
 
 export const rootRouter = Router();
 
 // feature routes
-rootRouter.use('/task', taskRouter);
-rootRouter.use('/user', userRouter);
+rootRouter.use('/auth', authRouter);
+rootRouter.use('/tasks', accessTokenMiddleware, taskRouter);
+rootRouter.use('/users', accessTokenMiddleware, userRouter);

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,1 +1,0 @@
-export { taskRouter } from './task.routes';

--- a/src/type-extensions/express-config.ts
+++ b/src/type-extensions/express-config.ts
@@ -1,5 +1,6 @@
 import 'express';
-import { QueryParamsTaskDto } from '../task/task.types';
+import { ActiveUser } from 'common/types';
+import { QueryParamsTaskDto } from 'task/task.types';
 
 declare module 'express-serve-static-core' {
   interface Request {
@@ -7,5 +8,7 @@ declare module 'express-serve-static-core' {
      * @property {QueryParamsTaskDto} [validatedQuery] - Зберігає валідовані та приведені параметри запиту після обробки за допомогою Zod схем.
      */
     validatedQuery?: QueryParamsTaskDto;
+
+    user: ActiveUser;
   }
 }

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,1 +1,0 @@
-export * from './user.routes';

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -39,6 +39,11 @@ export class UserControllerClass extends AbstractController {
     const user = await this.userService.delete(req.params.id);
     res.status(201).json(user);
   }
+
+  async me(req: TypedRequest, res: Response) {
+    const user = await this.userService.findOne('id', req.user.id);
+    res.status(201).json(user);
+  }
 }
 
 export const UserController = new UserControllerClass();

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -1,16 +1,20 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Nullable } from 'common/types';
 
+// TODO remove auth
 @Entity('users', { orderBy: { email: 'DESC' } })
 export class UserEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column({ unique: true })
-  email: string;
-
-  @Column({ select: false })
-  password: string;
+  email: string; // Denormalized field from AuthEntity.email
 
   @Column({ type: 'varchar', length: 50, nullable: true })
   name: Nullable<string>;
@@ -20,4 +24,10 @@ export class UserEntity {
 
   @Column({ nullable: true, type: 'date' })
   birthday: Nullable<Date>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/user/user.routes.ts
+++ b/src/user/user.routes.ts
@@ -16,6 +16,8 @@ userRouter.get(
   UserController.getAll,
 );
 
+userRouter.get('/me', UserController.me);
+
 userRouter.get(
   '/:id',
   validateMiddleware({ params: ParseIntSchema('id') }),

--- a/src/user/user.schemas.ts
+++ b/src/user/user.schemas.ts
@@ -1,16 +1,11 @@
 import { z } from 'zod';
-import { getQueryParamsDtoSchema } from 'common/schemas';
+import { EmailFieldSchema, getQueryParamsDtoSchema } from 'common/schemas';
 import { UserSortableFields } from './user.types';
 
 export const CreateUserSchema = z
   .object(
     {
-      email: z
-        .string({ message: 'email is required' })
-        .email({ message: 'email is invalid' }),
-      password: z
-        .string({ message: 'password is required' })
-        .min(3, { message: 'min password length is 3' }),
+      email: EmailFieldSchema,
       name: z
         .string({ message: 'name should be a string' })
         .nonempty({ message: 'name should not be empty' })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -4,13 +4,9 @@ import { NotFoundException } from 'common/exceptions';
 import { UserEntity } from 'user/user.entity';
 import { CreateUserDto, UpdateUserDto } from './user.types';
 import { MessageResponse } from 'common/types';
-import { CryptoService } from 'common/services';
 
 class UserServiceClass {
-  constructor(
-    private readonly cryptoService = CryptoService,
-    private readonly userRepository = UserRepository,
-  ) {}
+  constructor(private readonly userRepository = UserRepository) {}
 
   getAll(query: QueryParamsUserDto) {
     return this.userRepository.findAll(query);
@@ -29,16 +25,7 @@ class UserServiceClass {
   }
 
   async create(data: CreateUserDto): Promise<Omit<UserEntity, 'password'>> {
-    const hashedPassword = await this.cryptoService.hash(data.password);
-
-    const createdUser = await this.userRepository.create({
-      ...data,
-      password: hashedPassword,
-    });
-
-    const { password: _, ...user } = createdUser;
-
-    return user;
+    return this.userRepository.create(data);
   }
 
   async update(id: number, data: UpdateUserDto): Promise<UserEntity> {


### PR DESCRIPTION
## ✅ Модуль `auth` и авторизация

### 1. 🧹 Удалены `index.ts` из модулей

* **Причина:** они приводят к **циклическим зависимостям**, особенно при импорте `entities`, которые тянут за собой декораторы, репозитории, зависимости и прочее.
* **Решение:** явный импорт конкретных файлов (`./auth.entity`, `./user.entity` и т.д.) во избежание неявных импортов и сложных циклов.

---

### 2. 🔐 Реализован модуль `auth`

#### Общая архитектура:

* **Центральный контроллер** (`AuthControllerClass`) обрабатывает общий endpoint:

  * `POST /auth/refresh` — обновление access/refresh токенов;
  * endpoint не зависит от провайдера (`local`, `google`, `github`).
* **Провайдер `local`**:

  * Реализованы контроллер, сервис, схемы валидации (через `zod`);
  * Отдельные DTO и схемы: `RegisterSchema`, `LoginSchema`;
  * Возвращаются `access_token` (в теле) и `refresh_token` (в cookie);
  
* **Миддлвары:**

  * `accessTokenMiddleware` — извлекает `Bearer`-токен из заголовка и кладёт `req.user`;
  * `refreshTokenMiddleware` — извлекает `refresh_token` из HttpOnly cookie и тоже кладёт `req.user`.

---

### 3. 🔁 Построена односторонняя связь `UserEntity → AuthEntity`

* Использована связь:

  ```ts
  @ManyToOne(() => UserEntity, (user) => user.id, { onDelete: 'CASCADE' })
  user: UserEntity;
  ```
* **В `UserEntity` нет обратной связи** (`@OneToMany` удалён) — сознательный выбор для избежания ненужных связей и упрощения модели.
* В случае необходимости получить `auths` по пользователю — можно делать `relations` на уровне запроса.

---

### 4. ⚙️ Расширены типы `express`

```ts
declare module 'express-serve-static-core' {
  interface Request {
    /**
     * @property {QueryParamsTaskDto} [validatedQuery] - Зберігає валідовані та приведені параметри запиту після обробки за допомогою Zod схем.
     */
    validatedQuery?: QueryParamsTaskDto;

    user: ActiveUser;
  }
}
```

* **Назначение:** middleware (`accessTokenMiddleware`, `refreshTokenMiddleware`) безопасно присваивают `req.user`, не прибегая к кастам `as`.
* Добавлен `ActiveUser` тип:

  ```ts
  export interface ActiveUser {
    id: number;
    email: string;
  }
  ```
  
  
### 5. 📦 Postman коллекция
  
[task-manager.postman_collection.json](https://github.com/user-attachments/files/20710953/task-manager.postman_collection.json)

