### PR TITLE
feature(utils): create util to build queries

### DIFF
--- a/src/common/types/common.ts
+++ b/src/common/types/common.ts
@@ -17,3 +17,8 @@ export interface ActiveUser {
 }
 
 export type QueryParamsDtoSchema = z.infer<typeof _dummyQueryParamsDtoSchema>;
+
+export interface PaginatedResponse<DataType> {
+  data: DataType[];
+  total: number;
+}

--- a/src/common/utils/build-query-options/build-query-options.ts
+++ b/src/common/utils/build-query-options/build-query-options.ts
@@ -1,0 +1,47 @@
+import { FindOptionsWhere, ILike } from 'typeorm';
+import { Maybe, QueryParamsDtoSchema, SortOrder } from 'common/types';
+import { FindOptionsOrder } from 'typeorm/find-options/FindOptionsOrder';
+import { BuildQueryOptionsReturnValue } from 'common/utils/build-query-options/types';
+
+// ! HELPERS
+const buildWhereClause = <EntityType>(
+  searchableFields: (keyof EntityType)[],
+  search?: string,
+): FindOptionsWhere<EntityType>[] => {
+  if (!search || !searchableFields.length) return [];
+
+  return searchableFields.map((field) => ({
+    [field]: ILike(`%${search}%`),
+  })) as FindOptionsWhere<EntityType>[];
+};
+
+const buildOrderClause = <EntityType>(
+  order?: SortOrder,
+  sortBy?: keyof EntityType,
+): Maybe<FindOptionsOrder<EntityType>> => {
+  if (!sortBy || !order) return;
+
+  return {
+    [sortBy]: order.toUpperCase(),
+  } as FindOptionsOrder<EntityType>;
+};
+
+// ! MAIN FUNCTION
+export const buildQueryOptions = <
+  EntityType,
+  SearchableField extends keyof EntityType = keyof EntityType,
+>(
+  queryParams: QueryParamsDtoSchema,
+  searchableFields: SearchableField[],
+): BuildQueryOptionsReturnValue<EntityType> => {
+  const { page = 1, per_page = 10, order, sortBy, search } = queryParams;
+
+  return {
+    where: buildWhereClause<EntityType>(searchableFields, search),
+
+    order: buildOrderClause<EntityType>(order, sortBy as SearchableField),
+
+    skip: (page - 1) * per_page,
+    take: per_page,
+  };
+};

--- a/src/common/utils/build-query-options/index.ts
+++ b/src/common/utils/build-query-options/index.ts
@@ -1,2 +1,1 @@
-export * from './autobind';
 export { buildQueryOptions } from './build-query-options';

--- a/src/common/utils/build-query-options/types.ts
+++ b/src/common/utils/build-query-options/types.ts
@@ -1,0 +1,10 @@
+import { Maybe } from 'common/types';
+import { FindOptionsWhere } from 'typeorm';
+import { FindOptionsOrder } from 'typeorm/find-options/FindOptionsOrder';
+
+export interface BuildQueryOptionsReturnValue<EntityType> {
+  where: FindOptionsWhere<EntityType>[];
+  order?: Maybe<FindOptionsOrder<EntityType>>;
+  skip?: number;
+  take?: number;
+}

--- a/src/task/task.repository.ts
+++ b/src/task/task.repository.ts
@@ -1,41 +1,34 @@
-import { ILike } from 'typeorm';
-import { TaskEntity } from './task.entity';
-import { Nullable, QueryParamsDtoSchema } from 'common/types';
 import { AppDataSource } from 'database';
+import { TaskEntity } from './task.entity';
+import { buildQueryOptions } from 'common/utils';
 import { CreateTaskDto, UpdateTaskDto } from './task.types';
+import {
+  Nullable,
+  PaginatedResponse,
+  QueryParamsDtoSchema,
+} from 'common/types';
 
 class TaskRepositoryClass {
   constructor(
     private readonly repo = AppDataSource.getRepository(TaskEntity),
   ) {}
 
-  findAll({
-    search,
-    sortBy = 'createdAt',
-    order,
-    page = 1,
-    per_page = 10,
-  }: QueryParamsDtoSchema): Promise<{
-    data: TaskEntity[];
-    total: number;
-    page: number;
-    per_page: number;
-  }> {
-    const where = search
-      ? [{ title: ILike(`%${search}%`) }, { description: ILike(`%${search}%`) }]
-      : undefined;
+  async findAll(
+    queryParams: QueryParamsDtoSchema,
+  ): Promise<PaginatedResponse<TaskEntity>> {
+    const { skip, take, where, order } = buildQueryOptions<TaskEntity>(
+      queryParams,
+      ['title', 'description'],
+    );
 
-    const orderBy =
-      sortBy && order ? { [sortBy]: order.toUpperCase() } : undefined;
+    const [data, total] = await this.repo.findAndCount({
+      where,
+      order,
+      skip,
+      take,
+    });
 
-    return this.repo
-      .findAndCount({
-        where,
-        order: orderBy,
-        skip: (page - 1) * per_page,
-        take: per_page,
-      })
-      .then(([data, total]) => ({ data, total, page, per_page }));
+    return { data, total };
   }
 
   create(data: CreateTaskDto): Promise<TaskEntity> {


### PR DESCRIPTION
### :sparkles: Добавление утилиты для упрощения работы с методами `findAll`

#### Описание изменений:
- Создана утилита `buildQueryOptions`, которая помогает строить параметры `where`, `order`, `skip` и `take` для методов `findAll` в репозиториях. Это позволяет избавиться от дублирования кода при работе с фильтрацией, сортировкой и пагинацией.
- Утилита поддерживает:
  - Построение `where`-клаузы на основе переданных полей и строки поиска.
  - Построение `order`-клаузы для сортировки данных.
  - Учет параметров пагинации, таких как `page` и `per_page`.
- Добавлен интерфейс `PaginatedResponse` для единого подхода к структуре ответа пагинированных данных.
- Обновлены методы `findAll` в репозиториях:
  - `task.repository.ts`
  - `user.repository.ts`
  Теперь методы используют утилиту `buildQueryOptions`, что делает код более читаемым, компактным и легко расширяемым.

#### Причины изменений:
1. Устранение дублирующегося кода в методах `findAll` в репозиториях.
2. Улучшение читаемости и поддержки кода.
3. Упрощение добавления поиска/сортировки в новые репозитории.
4. Централизация логики построения параметров для запросов в едином месте.

#### Как протестировать:
1. Фильтрация, сортировка, пагинация и поиск работают корректно для следующих сущностей:
   - `Task`
   - `User`
2. Cтруктура ответа соответствует интерфейсу `PaginatedResponse`.


#### Дополнительно:
- Файл с утилитой: `src/common/utils/build-query-options`.
- Новые типы и интерфейсы добавлены в `src/common/types`.
