### PR TITLE
feature(User & Task): create User & Task relations

### DIFF
--- a/src/task/task.controller.ts
+++ b/src/task/task.controller.ts
@@ -1,6 +1,8 @@
 import { Response } from 'express';
+// task
 import { TaskService } from './task.service';
 import { CreateTaskDto, UpdateTaskDto } from './task.types';
+// common
 import { TypedRequest } from 'common/types';
 import { AbstractController } from 'common/abstract';
 
@@ -10,18 +12,17 @@ class TaskControllerClass extends AbstractController {
   }
 
   async getAll(req: TypedRequest, res: Response) {
-    const tasks = await this.taskService.findAll(req.validatedQuery!);
+    const tasks = await this.taskService.findAll(req.validatedQuery!, req.user);
     res.json(tasks);
   }
 
   async getById(req: TypedRequest<{ params: { id: number } }>, res: Response) {
-    console.log('req.params.id: ', typeof req.params.id);
-    const task = await this.taskService.findOne(req.params.id);
+    const task = await this.taskService.findOne(req.params.id, req.user);
     res.json(task);
   }
 
   async create(req: TypedRequest<{ body: CreateTaskDto }>, res: Response) {
-    const task = await this.taskService.create(req.body);
+    const task = await this.taskService.create(req.body, req.user);
     res.status(201).json(task);
   }
 
@@ -29,12 +30,16 @@ class TaskControllerClass extends AbstractController {
     req: TypedRequest<{ params: { id: number }; body: UpdateTaskDto }>,
     res: Response,
   ) {
-    const updated = await this.taskService.update(req.params.id, req.body);
+    const updated = await this.taskService.update(
+      req.params.id,
+      req.body,
+      req.user,
+    );
     res.json(updated);
   }
 
   async delete(req: TypedRequest<{ params: { id: number } }>, res: Response) {
-    const result = await this.taskService.delete(req.params.id);
+    const result = await this.taskService.delete(req.params.id, req.user);
     res.json(result);
   }
 }

--- a/src/task/task.entity.ts
+++ b/src/task/task.entity.ts
@@ -1,10 +1,13 @@
 import {
   Entity,
   Column,
+  ManyToOne,
+  JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { UserEntity } from 'user/user.entity';
 
 @Entity('tasks', { orderBy: { createdAt: 'DESC' } })
 export class TaskEntity {
@@ -17,8 +20,22 @@ export class TaskEntity {
   @Column({ type: 'text' })
   description: string;
 
-  @Column({ default: false })
+  @Column({ type: 'boolean', default: false })
   completed: boolean;
+
+  @ManyToOne(() => UserEntity, (user) => user.id, {
+    onDelete: 'CASCADE',
+    eager: false,
+  })
+  @JoinColumn({
+    name: 'author_id',
+    referencedColumnName: 'id',
+    foreignKeyConstraintName: 'fk_task_author_id',
+  })
+  author?: UserEntity;
+
+  @Column({ name: 'author_id', nullable: false })
+  authorId: number;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/task/task.types.ts
+++ b/src/task/task.types.ts
@@ -3,3 +3,8 @@ import { CreateTaskSchema, UpdateTaskSchema } from './task.schemas';
 
 export type CreateTaskDto = z.infer<typeof CreateTaskSchema>;
 export type UpdateTaskDto = z.infer<typeof UpdateTaskSchema>;
+
+export interface TaskFindOptions {
+  authorId?: number;
+  relations?: string[];
+}


### PR DESCRIPTION
### 🚀 Связь Task → User: `ManyToOne`

#### Изменения:

1. Добавлена связь `ManyToOne` от `TaskEntity` к `UserEntity`:

   * связующая колонка: `author_id`;
   * добавлены поля `author: UserEntity` и `authorId: number` в `TaskEntity`.

2. Обновлены соответствующие методы в `TaskController`, `TaskService` и `TaskRepository`:

   * теперь при создании и обновлении задач используется `authorId`;
   * `[GET] task/:id` загружает автора задачи через `relations`.

---   

### Breaking Changes ⚠️ 
Отвалится БД, потому что есть таски без `author_id`.
Миграцию не делал, по этому просто руками или удали таски без `author_id` из БД, или присвой им нужный `author_id` (id твоего юзера)
