### PR TITLE
feat(auth): added logout endpoint to clear refresh token cookie

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,6 +15,11 @@ class AuthControllerClass extends AbstractController {
     this.setRefreshTokenCookie(res, refresh_token);
     res.json({ access_token });
   }
+
+  logout(_req: Request, res: Response) {
+    this.clearRefreshTokenCookie(res);
+    res.status(204).send();
+  }
 }
 
 export const AuthController = new AuthControllerClass();

--- a/src/auth/auth.routes.ts
+++ b/src/auth/auth.routes.ts
@@ -7,6 +7,7 @@ export const authRouter = Router();
 
 // MAIN ROUTES
 authRouter.get('/refresh', refreshTokenMiddleware, AuthController.refresh);
+authRouter.post('/logout', AuthController.logout);
 
 // LOCAL PROVIDER ROUTES
 authRouter.use('/local', authLocalRouter);

--- a/src/common/abstract/abstract.controller.ts
+++ b/src/common/abstract/abstract.controller.ts
@@ -12,4 +12,8 @@ export abstract class AbstractController {
       sameSite: 'strict',
     });
   }
+
+  clearRefreshTokenCookie(res: Response) {
+    res.clearCookie('refresh_token');
+  }
 }


### PR DESCRIPTION
##  Added an endpoint /logout

### ✅ Description of task

✨Added a new `/logout` endpoint that removes the `refresh_token` from cookies when the user logs out.
⚠️Previously, only the `access_token` was removed from localStorage on the frontend, but the `refresh_token` stayed in cookies.    
 This allowed users to obtain a new access token via `/refresh` even after logging out, creating a security risk.  
🚪🔒 Now, when `/logout` is called, the server fully clears the `refresh_token` cookie, safely ending the user session.
